### PR TITLE
fix(migrator)!: keep table rebuilds on the pinned connection

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -17,8 +17,14 @@ type Migrator struct {
 	migrator.Migrator
 }
 
-func (m *Migrator) RunWithoutForeignKey(fc func() error) error {
-	return m.runWithoutForeignKey(func(*gorm.DB) error { return fc() })
+// RunWithoutForeignKey runs fc with foreign key enforcement disabled.
+//
+// fc receives the connection the PRAGMAs were applied to and must run all its
+// work on it: the pool may be limited to a single connection, so statements
+// issued on the original *gorm.DB would wait for the connection fc holds.
+// Nested migrator calls belong on tx as well, via tx.Migrator().
+func (m *Migrator) RunWithoutForeignKey(fc func(tx *gorm.DB) error) error {
+	return m.runWithoutForeignKey(fc)
 }
 
 // runWithoutForeignKey runs fc with foreign key enforcement disabled.
@@ -252,7 +258,7 @@ func (m *Migrator) HasConstraint(value any, name string) bool {
 			name = constraint.GetName()
 		}
 
-		rawDDL, err := m.getRawDDL(table)
+		rawDDL, err := m.getRawDDL(m.DB, table)
 		if err != nil {
 			return err
 		}
@@ -408,9 +414,12 @@ func (m *Migrator) GetIndexes(value any) ([]gorm.Index, error) {
 	return indexes, err
 }
 
-func (m *Migrator) getRawDDL(table string) (string, error) {
+// getRawDDL reads the CREATE TABLE statement of table. db selects the
+// connection to read from: callers running inside a pinned connection must
+// pass it, querying m.DB instead would wait for a second connection.
+func (m *Migrator) getRawDDL(db *gorm.DB, table string) (string, error) {
 	var createSQL string
-	err := m.DB.Raw("SELECT sql FROM sqlite_master WHERE type = ? AND tbl_name = ? AND name = ?", "table", table, table).Row().Scan(&createSQL)
+	err := db.Raw("SELECT sql FROM sqlite_master WHERE type = ? AND tbl_name = ? AND name = ?", "table", table, table).Row().Scan(&createSQL)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return "", err
 	}
@@ -436,7 +445,7 @@ func (m *Migrator) recreateTable(
 			table = *tablePtr
 		}
 
-		rawDDL, err := m.getRawDDL(table)
+		rawDDL, err := m.getRawDDL(execDB, table)
 		if err != nil {
 			return err
 		}

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -479,6 +480,125 @@ func TestDefaultValueRoundTrip(t *testing.T) {
 	}
 	if dv, ok := d.columns[0].DefaultValue(); !ok || dv != "hi" {
 		t.Errorf("legacy DefaultValue = (%q,%v), want (hi,true)", dv, ok)
+	}
+}
+
+type fkParent struct {
+	Id int `gorm:"column:id;primarykey"`
+}
+
+func (fkParent) TableName() string { return "fk_parents" }
+
+type fkChild struct {
+	ParentId int      `gorm:"column:parent_id"`
+	Parent   fkParent `gorm:"foreignkey:ParentId;references:Id"`
+	Extra    string   `gorm:"column:extra"`
+}
+
+func (fkChild) TableName() string { return "fk_children" }
+
+// openSingleConnDB serializes the pool on one connection, which is a common
+// setup for SQLite because only one writer is allowed anyway.
+func openSingleConnDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := openTestDB(t, "_pragma=foreign_keys(1)")
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	return db
+}
+
+// mustNotBlock fails instead of hanging the test binary forever.
+func mustNotBlock(t *testing.T, name string, fc func() error) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- fc() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("%s: %v", name, err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatalf("%s blocked, migration deadlocked on the single connection", name)
+	}
+}
+
+// Table rebuilds pin a connection for the PRAGMAs; every statement they run
+// must go to that connection. Reaching for the pool instead deadlocks as soon
+// as the pool has no second connection to hand out.
+func TestRecreateTableSingleConnection(t *testing.T) {
+	createChildren := "CREATE TABLE `fk_children` (`parent_id` integer, `extra` text)"
+
+	t.Run("AutoMigrate", func(t *testing.T) {
+		db := openSingleConnDB(t)
+		if err := db.Exec(createChildren).Error; err != nil {
+			t.Fatal(err)
+		}
+		// adds the missing foreign key, so the table gets rebuilt
+		mustNotBlock(t, "AutoMigrate", func() error {
+			return db.AutoMigrate(&fkParent{}, &fkChild{})
+		})
+	})
+
+	t.Run("DropColumn", func(t *testing.T) {
+		db := openSingleConnDB(t)
+		if err := db.Exec(createChildren).Error; err != nil {
+			t.Fatal(err)
+		}
+		mustNotBlock(t, "DropColumn", func() error {
+			return db.Migrator().DropColumn(&fkChild{}, "extra")
+		})
+	})
+
+	t.Run("AlterColumn", func(t *testing.T) {
+		db := openSingleConnDB(t)
+		if err := db.Exec(createChildren).Error; err != nil {
+			t.Fatal(err)
+		}
+		mustNotBlock(t, "AlterColumn", func() error {
+			return db.Migrator().AlterColumn(&fkChild{}, "extra")
+		})
+	})
+
+	t.Run("DropConstraint", func(t *testing.T) {
+		db := openSingleConnDB(t)
+		if err := db.AutoMigrate(&fkParent{}, &fkChild{}); err != nil {
+			t.Fatal(err)
+		}
+		mustNotBlock(t, "DropConstraint", func() error {
+			return db.Migrator().DropConstraint(&fkChild{}, "Parent")
+		})
+	})
+}
+
+// The callback of RunWithoutForeignKey gets the pinned connection and can use
+// it for queries and for nested migrator calls.
+func TestRunWithoutForeignKeySingleConnection(t *testing.T) {
+	db := openSingleConnDB(t)
+	if err := db.AutoMigrate(&fkParent{}, &fkChild{}); err != nil {
+		t.Fatal(err)
+	}
+
+	m, ok := db.Migrator().(*Migrator)
+	if !ok {
+		t.Fatalf("migrator = %T, want *sqlite.Migrator", db.Migrator())
+	}
+
+	mustNotBlock(t, "RunWithoutForeignKey", func() error {
+		return m.RunWithoutForeignKey(func(tx *gorm.DB) error {
+			var count int
+			if err := tx.Raw("SELECT count(*) FROM fk_parents").Row().Scan(&count); err != nil {
+				return err
+			}
+			return tx.Migrator().DropTable(&fkChild{})
+		})
+	})
+
+	if db.Migrator().HasTable(&fkChild{}) {
+		t.Error("HasTable(fk_children) = true after DropTable, want false")
 	}
 }
 


### PR DESCRIPTION
Fixes #24.

`runWithoutForeignKey` (added in 9563ce7, released in v1.2.0) pins a connection so the `PRAGMA foreign_keys` toggles and the rebuild transaction share one session. `recreateTable` gets that connection as `execDB`, but the first thing it does is read the table DDL through `m.DB`:

```go
rawDDL, err := m.getRawDDL(table)   // m.DB.Raw(...) -> asks the pool for a connection
```

With `SetMaxOpenConns(1)` — the usual way to serialize SQLite writers so concurrent writes wait on `busy_timeout` instead of failing with `SQLITE_BUSY` — the pool has no second connection to hand out and the query waits for the one the caller is holding. `AlterColumn`, `DropColumn`, `CreateConstraint` and `DropConstraint` deadlock, and `AutoMigrate` hangs whenever an existing table is missing a foreign key declared in the model. Larger pools only make it rarer: it happens whenever the other connections are busy.

`getRawDDL` now takes the database to read from, so the rebuild stays on the pinned connection.

`RunWithoutForeignKey` had the same problem one level up. It pinned a connection but gave the callback no handle on it, so anything the callback did on the original `*gorm.DB` — a query, or a nested migrator call that pins again — waited for the connection it was holding. It now passes the pinned connection to the callback, matching the internal variant. That is a breaking signature change, hence the `!`; callers do their work on `tx`, and nested migrator calls go through `tx.Migrator()`.

Regression tests run each operation with `SetMaxOpenConns(1)` and fail instead of hanging the test binary. On `main` all four subtests of `TestRecreateTableSingleConnection` time out; with this change the suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
